### PR TITLE
Fix monster equipment rendering and formation panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,11 +30,6 @@
 
     <div id="ui-container">
         <div id="squad-management"></div>
-
-        <div id="formation-placement">
-            <div id="formation-grid"></div>
-            <div id="formation-squad-list"></div>
-        </div>
     </div>
 
     <div id="ui-panel" class="ui-frame">

--- a/src/game.js
+++ b/src/game.js
@@ -213,6 +213,7 @@ export class Game {
         this.speechBubbleManager = this.managers.SpeechBubbleManager;
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
+        this.monsterManager.equipmentRenderManager = this.equipmentRenderManager;
         this.traitManager = this.managers.TraitManager;
         this.mercenaryManager.setTraitManager(this.traitManager);
         this.monsterManager.setTraitManager(this.traitManager);

--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -20,6 +20,7 @@ export class MonsterManager {
         this.monsters = [];
         this.metaAIManager = null;
         this.traitManager = null;
+        this.equipmentRenderManager = null;
         console.log("[MonsterManager] Initialized");
 
         if (this.eventManager) {
@@ -41,7 +42,14 @@ export class MonsterManager {
         this.metaAIManager = metaAIManager;
     }
 
+    setEquipmentRenderManager(manager) {
+        this.equipmentRenderManager = manager;
+    }
+
     addMonster(monster) {
+        if (this.equipmentRenderManager) {
+            monster.equipmentRenderManager = this.equipmentRenderManager;
+        }
         this.monsters.push(monster);
         if (this.metaAIManager) {
             const group =


### PR DESCRIPTION
## Summary
- ensure monsters draw equipment by assigning an EquipmentRenderManager
- remove duplicate formation grid from layout
- link monster manager with renderer during game setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c468109888327b73854319df2dc0e